### PR TITLE
Never call back

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -94,7 +94,7 @@ export default class StartServerPlugin {
     }
   }
 
-  startServer(compilation, callback) {
+  startServer(compilation) {
     const {options} = this;
     let name;
     const names = Object.keys(compilation.assets);
@@ -120,7 +120,6 @@ export default class StartServerPlugin {
 
     this._startServer(worker => {
       this.worker = worker;
-      callback();
     });
   }
 


### PR DESCRIPTION
I have no idea what this might break, but it fixes the error message `"No such label 'emitAssets' for WebpackLogger.timeEnd()"`, followed by a crash, which occurs upon typing `rs` to restart the server.